### PR TITLE
Rename once more, this time to `Roboverse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BelvedereSim - Web front-end for the Gazebo simulator
+# Roboverse - Web front-end for the Gazebo simulator
 
-BelvedereSim is a fork of [osrf/gzweb](https://github.com/osrf/gzweb) that is planned to be rewritten in Rust and TypeScript.
+Roboverse is a fork of [osrf/gzweb](https://github.com/osrf/gzweb) that is planned to be rewritten in Rust and TypeScript.
 
 Like gzweb, it is also a WebGL client for [Gazebo](http://gazebosim.org).and like gzclient, it's a front-end graphical interface to gzserver and provides visualization of the simulation.
 


### PR DESCRIPTION
Gotta keep iterating on that name.

Roboverse has a better ring to it.